### PR TITLE
 #5 Don't ping Consul until startup completes

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -140,9 +140,11 @@ public abstract class ConsulBundle<C extends Configuration>
 
         // Scheduled a periodic check to Consul to keep service alive
         final Duration interval = consulConfig.getCheckInterval();
-        executor.scheduleAtFixedRate(
-                new ConsulServiceCheckTask(consul, serviceId),
-                INITIAL_DELAY_SECS, interval.getQuantity(), interval.getUnit());
+        ConsulServiceCheckTask serviceCheckTask = new ConsulServiceCheckTask(consul, serviceId);
+        executor.scheduleAtFixedRate(serviceCheckTask, INITIAL_DELAY_SECS,
+                interval.getQuantity(), interval.getUnit());
+		
+        environment.lifecycle().addLifeCycleListener(serviceCheckTask);
 
         // Register a ping healthcheck to the Consul agent
         environment.healthChecks().register("consul",

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulServiceCheckTaskTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulServiceCheckTaskTest.java
@@ -15,7 +15,10 @@
  */
 package com.smoketurner.dropwizard.consul.core;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.junit.Before;
@@ -38,7 +41,22 @@ public class ConsulServiceCheckTaskTest {
 
     @Test
     public void testRun() throws Exception {
+        task.lifeCycleStarted(null);
         task.run();
         verify(agent).pass(SERVICE_ID);
+    }
+
+    @Test
+    public void testPreLifecycleStartedEvent() throws Exception {
+        task.run();
+        verify(agent, never()).pass(anyString());
+    }
+
+    @Test
+    public void testPostLifecycleStoppingEvent() throws Exception {
+        testRun();
+        task.lifeCycleStopping(null);
+        reset(agent);
+        testPreLifecycleStartedEvent();
     }
 }


### PR DESCRIPTION
This adds the Lifecycle.Listener interface to the ConsulServiceCheckTask and registers it so that we can know when the server has started successfully.  This prevents attempting to send "pass" pings to Consul for our service before it is registered.

This is particularly important for any Dropwizard commands you may be using, as the service is never registered for the duration of the command, and causes a lot of useless log output.
