### PR TITLE
Adds support for Consul tags

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
@@ -34,6 +34,7 @@ public class ConsulFactory {
     private String serviceName;
     private Optional<Integer> servicePort = Optional.absent();
     private Optional<String> serviceAddress = Optional.absent();
+    private Optional<Iterable<String>> tags = Optional.absent();
 
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
@@ -61,6 +62,16 @@ public class ConsulFactory {
     @JsonProperty
     public void setSeviceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    @JsonProperty
+    public Optional<Iterable<String>> getTags() {
+        return tags;
+    }
+
+    @JsonProperty
+    public void setTags(Iterable<String> tags) {
+        this.tags = Optional.fromNullable(tags);
     }
 
     @JsonProperty

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
@@ -34,6 +34,7 @@ public class ConsulAdvertiser {
             .getLogger(ConsulAdvertiser.class);
     private final AtomicReference<Integer> servicePort = new AtomicReference<>();
     private final AtomicReference<String> serviceAddress = new AtomicReference<>();
+    private final AtomicReference<Iterable<String>> tags = new AtomicReference<>();
     private final ConsulFactory configuration;
     private final Consul consul;
     private final String serviceId;
@@ -79,6 +80,13 @@ public class ConsulAdvertiser {
                     configuration.getServiceAddress().get());
             serviceAddress.set(configuration.getServiceAddress().get());
         }
+        
+        if (configuration.getTags().isPresent()) {
+        	LOGGER.info(
+        			"Using \"{}\" as tags from the configuration file",
+        			configuration.getTags().get());
+        	tags.set(configuration.getTags().get());
+        }
     }
 
     /**
@@ -123,6 +131,11 @@ public class ConsulAdvertiser {
         // If we have set the serviceAddress, add it to the registration.
         if (serviceAddress.get() != null) {
             builder.address(serviceAddress.get());
+        }
+        
+        // If we have tags, add them to the registration.
+        if (tags.get() != null) {
+        	builder.tags(tags.get());
         }
 
         try {

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -15,6 +15,9 @@
  */
 package com.smoketurner.dropwizard.consul.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -89,6 +92,26 @@ public class ConsulAdvertiserTest {
                 .check(Registration.RegCheck.ttl(3L)).name("test");
 
         verify(agent).register(builder.id(anyString()).build());
+    }
+    
+    @Test
+    public void testTagsFromConfig() {
+    	List<String> tags = new ArrayList<String>();
+    	tags.add("test");
+    	tags.add("second-test");
+    	factory.setTags(tags);
+
+        when(agent.isRegistered(serviceId)).thenReturn(false);
+        final ConsulAdvertiser advertiser = new ConsulAdvertiser(factory,
+                consul, serviceId);
+        advertiser.register(8080);
+
+        ImmutableRegistration registration = ImmutableRegistration.builder()
+        		.tags(tags)
+                .check(Registration.RegCheck.ttl(3L)).name("test")
+                .port(8080).id(serviceId).build();
+
+        verify(agent).register(registration);
     }
 
     @Test


### PR DESCRIPTION
This adds support for specifying Consul tags in the configuration file. This enables Dropwizard to play nicely with [Fabio](https://github.com/eBay/fabio) and similar libraries and services that rely on tag information.
