### PR TITLE
Add support for communication scheme configuration

### DIFF
--- a/consul-ribbon/src/main/java/com/smoketurner/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
+++ b/consul-ribbon/src/main/java/com/smoketurner/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
@@ -15,15 +15,16 @@
  */
 package com.smoketurner.dropwizard.consul.ribbon;
 
-import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.ws.rs.client.Client;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
 import com.orbitz.consul.Consul;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.client.Client;
+import java.util.Objects;
 
 public class RibbonJerseyClientBuilder {
 
@@ -33,7 +34,7 @@ public class RibbonJerseyClientBuilder {
 
     /**
      * Constructor
-     * 
+     *
      * @param environment
      *            Dropwizard environment
      * @param consul
@@ -116,7 +117,7 @@ public class RibbonJerseyClientBuilder {
         final ZoneAwareLoadBalancer<Server> loadBalancer = factory
                 .build(configuration);
 
-        final RibbonJerseyClient client = new RibbonJerseyClient(loadBalancer,
+        final RibbonJerseyClient client = new RibbonJerseyClient(configuration.getScheme(), loadBalancer,
                 jerseyClient);
 
         environment.lifecycle().manage(new Managed() {

--- a/consul-ribbon/src/main/java/com/smoketurner/dropwizard/consul/ribbon/RibbonLoadBalancerConfiguration.java
+++ b/consul-ribbon/src/main/java/com/smoketurner/dropwizard/consul/ribbon/RibbonLoadBalancerConfiguration.java
@@ -18,6 +18,7 @@ package com.smoketurner.dropwizard.consul.ribbon;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
+import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +29,9 @@ public class RibbonLoadBalancerConfiguration {
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration refreshInterval = Duration.seconds(10);
 
+    @NotBlank
+    private String scheme = "http";
+
     @JsonProperty
     public Duration getRefreshInterval() {
         return refreshInterval;
@@ -36,5 +40,15 @@ public class RibbonLoadBalancerConfiguration {
     @JsonProperty
     public void setRefreshInterval(Duration refreshInterval) {
         this.refreshInterval = refreshInterval;
+    }
+
+    @JsonProperty
+    public String getScheme() {
+        return scheme;
+    }
+
+    @JsonProperty
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
     }
 }


### PR DESCRIPTION
If I don't do `builder.scheme("http")` in `target(String uri)` method, I get an "org.apache.http.ProtocolException: Target host is not specified". So I added something to allow configuring it.
