### PR TITLE
Use DeregisterCriticalServiceAfter in Consul 0.7

### DIFF
--- a/consul-core/pom.xml
+++ b/consul-core/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.orbitz.consul</groupId>
             <artifactId>consul-client</artifactId>
-            <version>0.13.0</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -31,8 +31,8 @@ import org.junit.Test;
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.ConsulException;
+import com.orbitz.consul.model.agent.ImmutableRegCheck;
 import com.orbitz.consul.model.agent.ImmutableRegistration;
-import com.orbitz.consul.model.agent.Registration;
 import com.smoketurner.dropwizard.consul.ConsulFactory;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.setup.Environment;
@@ -71,8 +71,10 @@ public class ConsulAdvertiserTest {
 
         final ImmutableRegistration registration = ImmutableRegistration
                 .builder().port(8080)
-                .check(Registration.RegCheck
-                        .http("http://127.0.0.1:8081/admin/healthcheck", 1))
+                .check(ImmutableRegCheck.builder()
+                        .http("http://127.0.0.1:8081/admin/healthcheck")
+                        .interval("1s").deregisterCriticalServiceAfter("1m")
+                        .build())
                 .name("test").id(serviceId).build();
 
         verify(agent).register(registration);
@@ -98,8 +100,10 @@ public class ConsulAdvertiserTest {
 
         final ImmutableRegistration registration = ImmutableRegistration
                 .builder().id(serviceId).port(8888).address("127.0.0.1")
-                .check(Registration.RegCheck
-                        .http("http://127.0.0.1:8081/admin/healthcheck", 1))
+                .check(ImmutableRegCheck.builder()
+                        .http("http://127.0.0.1:8081/admin/healthcheck")
+                        .interval("1s").deregisterCriticalServiceAfter("1m")
+                        .build())
                 .name("test").build();
 
         verify(agent).register(registration);
@@ -117,8 +121,10 @@ public class ConsulAdvertiserTest {
 
         final ImmutableRegistration registration = ImmutableRegistration
                 .builder().tags(tags)
-                .check(Registration.RegCheck
-                        .http("http://127.0.0.1:8081/admin/healthcheck", 1))
+                .check(ImmutableRegCheck.builder()
+                        .http("http://127.0.0.1:8081/admin/healthcheck")
+                        .interval("1s").deregisterCriticalServiceAfter("1m")
+                        .build())
                 .name("test").port(8080).id(serviceId).build();
 
         verify(agent).register(registration);


### PR DESCRIPTION
Make use of new DeregisterCriticalServiceAfter parameter in Consul 0.7 to deregister the service after 1 minute

Makes use of https://github.com/hashicorp/consul/pull/2276, https://github.com/OrbitzWorldwide/consul-client/pull/165 and https://github.com/OrbitzWorldwide/consul-client/pull/168
