### PR TITLE
Allow bundle to be disabled in configuration

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -119,27 +119,30 @@ public abstract class ConsulBundle<C extends Configuration>
     @Override
     public void run(C configuration, Environment environment) throws Exception {
         final ConsulFactory consulConfig = getConsulFactory(configuration);
-
         if (!consulConfig.getEnabled()) {
             LOGGER.warn("Consul bundle disabled.");
         } else {
-            consulConfig.setSeviceName(serviceName);
-            final Consul consul = consulConfig.build();
-            final String serviceId = getConsulServiceId();
-            final ConsulAdvertiser advertiser = new ConsulAdvertiser(environment,
-                    consulConfig, consul, serviceId);
-
-            // Register a Jetty listener to get the listening host and port
-            environment.lifecycle().addServerLifecycleListener(
-                    new ConsulServiceListener(advertiser));
-
-            // Register a ping healthcheck to the Consul agent
-            environment.healthChecks().register("consul",
-                    new ConsulHealthCheck(consul));
-
-            // Register a shutdown manager to deregister the service
-            environment.lifecycle().manage(new ConsulAdvertiserManager(advertiser));
+            runEnabled(consulConfig, environment);
         }
+    }
+
+    public void runEnabled(ConsulFactory consulConfig, Environment environment) throws Exception {
+        consulConfig.setSeviceName(serviceName);
+        final Consul consul = consulConfig.build();
+        final String serviceId = getConsulServiceId();
+        final ConsulAdvertiser advertiser = new ConsulAdvertiser(environment,
+            consulConfig, consul, serviceId);
+
+        // Register a Jetty listener to get the listening host and port
+        environment.lifecycle().addServerLifecycleListener(
+            new ConsulServiceListener(advertiser));
+
+        // Register a ping healthcheck to the Consul agent
+        environment.healthChecks().register("consul",
+            new ConsulHealthCheck(consul));
+
+        // Register a shutdown manager to deregister the service
+        environment.lifecycle().manage(new ConsulAdvertiserManager(advertiser));
     }
 
     /**

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
@@ -32,6 +32,7 @@ public class ConsulFactory {
             .fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT);
 
     private String serviceName;
+    private Boolean enabled = true;
     private Optional<Integer> servicePort = Optional.absent();
     private Optional<Integer> adminPort = Optional.absent();
     private Optional<String> serviceAddress = Optional.absent();
@@ -40,6 +41,16 @@ public class ConsulFactory {
     @NotNull
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration checkInterval = Duration.seconds(1);
+
+    @JsonProperty
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    @JsonProperty
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
 
     @JsonProperty
     public HostAndPort getEndpoint() {

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulBundleTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulBundleTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 Smoke Turner, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.smoketurner.dropwizard.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+
+public class ConsulBundleTest {
+
+    private ConsulBundle bundle;
+    private Configuration config;
+    private final ConsulFactory factory = spy(new ConsulFactory());
+    private final Environment environment = mock(Environment.class);
+
+    @Before
+    public void setUp() throws Exception {
+        class TestConfiguration extends Configuration implements ConsulConfiguration {
+            @Override
+            public ConsulFactory getConsulFactory(Configuration c) {
+                return factory;
+            }
+        }
+
+        bundle = spy(new ConsulBundle<TestConfiguration>("test") {
+            @Override
+            public ConsulFactory getConsulFactory(TestConfiguration c) {
+                return c.getConsulFactory(c);
+            }
+        });
+
+        config = new TestConfiguration();
+        doNothing().when(bundle).runEnabled(factory, environment);
+    }
+
+    @Test
+    public void testDefaultsToEnabled() throws Exception {
+        assertThat(factory.getEnabled()).isTrue();
+    }
+
+    @Test
+    public void testEnabled() throws Exception {
+        doReturn(true).when(factory).getEnabled();
+        bundle.run(config, environment);
+        verify(bundle, times(1)).runEnabled(factory, environment);
+    }
+
+    @Test
+    public void testNotEnabled() throws Exception {
+        doReturn(false).when(factory).getEnabled();
+        bundle.run(config, environment);
+        verify(bundle, times(0)).runEnabled(factory, environment);
+    }
+
+}


### PR DESCRIPTION
It is useful to be able to disable bundles at the configuration level. This allows for a configuration like:

```yaml
consul:
  enabled: false
```

This is useful for environments (like staging or test) that do not utilize consul.