### PR TITLE
Add an admin task for toggling maintenance mode in consul

### DIFF
--- a/consul-core/pom.xml
+++ b/consul-core/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.orbitz.consul</groupId>
             <artifactId>consul-client</artifactId>
-            <version>0.13.3</version>
+            <version>0.13.6</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/consul-core/pom.xml
+++ b/consul-core/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.orbitz.consul</groupId>
             <artifactId>consul-client</artifactId>
-            <version>0.13.6</version>
+            <version>0.13.8</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -29,6 +29,7 @@ import com.smoketurner.dropwizard.consul.core.ConsulAdvertiser;
 import com.smoketurner.dropwizard.consul.core.ConsulServiceListener;
 import com.smoketurner.dropwizard.consul.health.ConsulHealthCheck;
 import com.smoketurner.dropwizard.consul.managed.ConsulAdvertiserManager;
+import com.smoketurner.dropwizard.consul.task.MaintenanceTask;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -144,6 +145,9 @@ public abstract class ConsulBundle<C extends Configuration>
 
         // Register a shutdown manager to deregister the service
         environment.lifecycle().manage(new ConsulAdvertiserManager(advertiser));
+
+        // Add an administrative task to toggle maintenance mode
+        environment.admin().addTask(new MaintenanceTask(consul, serviceId));
     }
 
     /**

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
@@ -52,7 +52,8 @@ public class MaintenanceTask extends Task {
             PrintWriter output) throws Exception {
 
         if (!parameters.containsKey("enable")) {
-            throw new Exception("Parameter \"enable\" not found");
+            throw new IllegalArgumentException(
+                    "Parameter \"enable\" not found");
         }
 
         final boolean enable = Boolean

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
@@ -52,11 +52,8 @@ public class MaintenanceTask extends Task {
     public void execute(ImmutableMultimap<String, String> parameters,
             PrintWriter output) throws Exception {
 
-        output.println(String.format("params: %s", parameters));
-        output.flush();
-
         if (!parameters.containsKey("enable")) {
-            LOGGER.error("enable parameter not found in request");
+            LOGGER.error("required \"enable\" parameter not found in request");
             return;
         }
 

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016 Smoke Turner, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.smoketurner.dropwizard.consul.task;
+
+import java.io.PrintWriter;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMultimap;
+import com.orbitz.consul.Consul;
+import com.orbitz.consul.ConsulException;
+import io.dropwizard.servlets.tasks.Task;
+
+public class MaintenanceTask extends Task {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MaintenanceTask.class);
+    private final Consul consul;
+    private final String serviceId;
+
+    /**
+     * Constructor
+     *
+     * @param consul
+     *            Consul client
+     * @param serviceId
+     *            Service ID to toggle maintenance mode
+     */
+    public MaintenanceTask(@Nonnull final Consul consul,
+            @Nonnull final String serviceId) {
+        super("maintenance");
+        this.consul = Objects.requireNonNull(consul);
+        this.serviceId = Objects.requireNonNull(serviceId);
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters,
+            PrintWriter output) throws Exception {
+
+        output.println(String.format("params: %s", parameters));
+        output.flush();
+
+        if (!parameters.containsKey("enable")) {
+            LOGGER.error("enable parameter not found in request");
+            return;
+        }
+
+        final boolean enable = Boolean
+                .valueOf(parameters.get("enable").asList().get(0));
+        final String reason;
+        if (parameters.containsKey("reason")) {
+            reason = parameters.get("reason").asList().get(0);
+        } else {
+            reason = null;
+        }
+
+        try {
+            consul.agentClient().toggleMaintenanceMode(serviceId, enable,
+                    reason);
+        } catch (ConsulException e) {
+            LOGGER.warn(String.format(
+                    "Unable to toggle maintenance mode for service %s",
+                    serviceId), e);
+            return;
+        }
+
+        final String message;
+        if (enable) {
+            if (!Strings.isNullOrEmpty(reason)) {
+                message = String.format(
+                        "Enabling maintenance mode for service %s (reason: %s)",
+                        serviceId, reason);
+            } else {
+                message = String.format(
+                        "Enabling maintenance mode for service %s (no reason given)",
+                        serviceId);
+            }
+        } else {
+            message = String.format("Disabling maintenance mode for service %s",
+                    serviceId);
+        }
+        LOGGER.warn(message);
+        output.println(message);
+        output.flush();
+    }
+}

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
@@ -58,7 +58,7 @@ public class MaintenanceTask extends Task {
         }
 
         final boolean enable = Boolean
-                .valueOf(parameters.get("enable").asList().get(0));
+                .parseBoolean(parameters.get("enable").asList().get(0));
         final String reason;
         if (parameters.containsKey("reason")) {
             reason = parameters.get("reason").asList().get(0);

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/task/MaintenanceTask.java
@@ -59,9 +59,10 @@ public class MaintenanceTask extends Task {
                 .parseBoolean(parameters.get("enable").asList().get(0));
         final String reason;
         if (parameters.containsKey("reason")) {
-            reason = parameters.get("reason").asList().get(0);
+            reason = Strings
+                    .nullToEmpty(parameters.get("reason").asList().get(0));
         } else {
-            reason = null;
+            reason = "";
         }
 
         if (enable) {

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,14 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray</id>
+            <name>bintray</name>
+            <url>http://jcenter.bintray.com</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
This doesn't currently work though due to https://github.com/OrbitzWorldwide/consul-client/commit/f459947cbbb645699deed63152c6c82a3ab07f12#commitcomment-20226372

```
Consul request failed with status [405]: 
com.orbitz.consul.ConsulException: Consul request failed with status [405]: 
	at com.orbitz.consul.util.Http.handle(Http.java:45)
	at com.orbitz.consul.AgentClient.toggleMaintenanceMode(AgentClient.java:580)
```

Fixed in https://github.com/OrbitzWorldwide/consul-client/pull/197