### PR TITLE
Code to avoid overwriting serviceName when provided

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -36,7 +36,7 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
-import static org.assertj.core.util.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Replace variables with values from Consul KV. By default, this only works

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -36,6 +36,8 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 /**
  * Replace variables with values from Consul KV. By default, this only works
  * with a Consul agent running on localhost:8500 (the default) as there's no way
@@ -51,7 +53,7 @@ public abstract class ConsulBundle<C extends Configuration>
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ConsulBundle.class);
-    private final String serviceName;
+    private final String defaultServiceName;
     private final boolean strict;
     private final boolean substitutionInVariables;
 
@@ -89,7 +91,7 @@ public abstract class ConsulBundle<C extends Configuration>
      */
     public ConsulBundle(@Nonnull final String name, boolean strict,
             boolean substitutionInVariables) {
-        this.serviceName = Objects.requireNonNull(name);
+        this.defaultServiceName = Objects.requireNonNull(name);
         this.strict = strict;
         this.substitutionInVariables = substitutionInVariables;
     }
@@ -129,7 +131,13 @@ public abstract class ConsulBundle<C extends Configuration>
 
     protected void runEnabled(ConsulFactory consulConfig,
             Environment environment) {
-        consulConfig.setSeviceName(serviceName);
+        if (isBlank(consulConfig.getServiceName())){
+            consulConfig.setSeviceName(defaultServiceName);
+        }
+        setupEnvironment(consulConfig, environment);
+    }
+
+    protected void setupEnvironment(ConsulFactory consulConfig, Environment environment) {
         final Consul consul = consulConfig.build();
         final String serviceId = getConsulServiceId();
         final ConsulAdvertiser advertiser = new ConsulAdvertiser(environment,

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulBundle.java
@@ -36,7 +36,7 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.assertj.core.util.Strings.isNullOrEmpty;
 
 /**
  * Replace variables with values from Consul KV. By default, this only works
@@ -131,7 +131,7 @@ public abstract class ConsulBundle<C extends Configuration>
 
     protected void runEnabled(ConsulFactory consulConfig,
             Environment environment) {
-        if (isBlank(consulConfig.getServiceName())){
+        if (isNullOrEmpty(consulConfig.getServiceName())){
             consulConfig.setSeviceName(defaultServiceName);
         }
         setupEnvironment(consulConfig, environment);

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulBundleTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulBundleTest.java
@@ -51,7 +51,7 @@ public class ConsulBundleTest {
             }
         });
 
-        doNothing().when(bundle).runEnabled(factory, environment);
+        doNothing().when(bundle).setupEnvironment(factory, environment);
     }
 
     @Test
@@ -63,13 +63,28 @@ public class ConsulBundleTest {
     public void testEnabled() throws Exception {
         doReturn(true).when(factory).isEnabled();
         bundle.run(config, environment);
-        verify(bundle, times(1)).runEnabled(factory, environment);
+        verify(bundle, times(1)).setupEnvironment(factory, environment);
     }
 
     @Test
     public void testNotEnabled() throws Exception {
         doReturn(false).when(factory).isEnabled();
         bundle.run(config, environment);
-        verify(bundle, times(0)).runEnabled(factory, environment);
+        verify(bundle, times(0)).setupEnvironment(factory, environment);
     }
+
+    @Test
+    public void testMissingServiceName() throws Exception {
+        factory.setSeviceName(null);
+        bundle.run(config, environment);
+        assertThat(factory.getServiceName()).isEqualTo("test");
+    }
+
+    @Test
+    public void testPopulatedServiceName() throws Exception {
+        factory.setSeviceName("test-service-name");
+        bundle.run(config, environment);
+        assertThat(factory.getServiceName()).isEqualTo("test-service-name");
+    }
+
 }


### PR DESCRIPTION
There is a bug when the serviceName is provided in config, the plugin will always ignore it.