### PR TITLE
removed unknown config value from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ consul:
   endpoint: localhost:8500
   # service port
   servicePort: 8080
-  # service time to live
-  serviceTTL: 30 seconds
   # check interval frequency
   checkInterval: 1 second
 ```


### PR DESCRIPTION
Config value is shown in the readme file which isn't actually there.

Causes errors when following the example.