### PR TITLE
Bump Dropwizard version to 1.3.0

### DIFF
--- a/consul-core/pom.xml
+++ b/consul-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.smoketurner.dropwizard</groupId>
         <artifactId>dropwizard-consul</artifactId>
-        <version>1.2.3-3-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>consul-core</artifactId>

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/config/ConsulLookup.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/config/ConsulLookup.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.text.StrLookup;
+import org.apache.commons.text.StrLookup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.orbitz.consul.Consul;
@@ -38,7 +38,7 @@ public class ConsulLookup extends StrLookup<Object> {
 
     /**
      * Create a new instance with strict behavior.
-     * 
+     *
      * @param consul
      *            Consul client
      */

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/config/ConsulSubstitutor.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/config/ConsulSubstitutor.java
@@ -16,9 +16,9 @@
 package com.smoketurner.dropwizard.consul.config;
 
 import javax.annotation.Nonnull;
-import org.apache.commons.lang3.text.StrSubstitutor;
 import com.orbitz.consul.Consul;
 import io.dropwizard.configuration.UndefinedEnvironmentVariableException;
+import org.apache.commons.text.StrSubstitutor;
 
 /**
  * A custom {@link StrSubstitutor} using Consul KV as lookup source.

--- a/consul-example/pom.xml
+++ b/consul-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.smoketurner.dropwizard</groupId>
         <artifactId>dropwizard-consul</artifactId>
-        <version>1.2.3-3-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>consul-example</artifactId>

--- a/consul-ribbon/pom.xml
+++ b/consul-ribbon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.smoketurner.dropwizard</groupId>
         <artifactId>dropwizard-consul</artifactId>
-        <version>1.2.3-3-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>consul-ribbon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.smoketurner.dropwizard</groupId>
     <artifactId>dropwizard-consul</artifactId>
-    <version>1.2.3-3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dropwizard-consul</name>
@@ -27,7 +27,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
         <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
-        <dropwizard.version>1.2.3</dropwizard.version>
+        <dropwizard.version>1.3.0-rc6</dropwizard.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Bump Dropwizard version to 1.3.0.
- Change import for deprecated classes StrSubstitutor and StrLookup