### PR TITLE
ConsulAdvertiser - make getHealthCheckUrl protected

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
@@ -175,7 +175,7 @@ public class ConsulAdvertiser {
         }
     }
 
-    private String getHealthCheckUrl() {
+    protected String getHealthCheckUrl() {
         final UriBuilder builder = UriBuilder
                 .fromPath(environment.getAdminContext().getContextPath());
         builder.path("healthcheck");


### PR DESCRIPTION
If we want to use a different health-check url for consul to poll, it's not currently possible to do so. Changing the getHealthCheckUrl method to protected will allow us to override the default url generation.