### PR TITLE
Set the health check protocol to the service protocol

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
@@ -23,12 +23,13 @@ import com.orbitz.consul.model.agent.ImmutableRegistration;
 import com.orbitz.consul.model.agent.Registration;
 import com.smoketurner.dropwizard.consul.ConsulFactory;
 import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.UriBuilder;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.ws.rs.core.UriBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConsulAdvertiser {
 
@@ -154,7 +155,7 @@ public class ConsulAdvertiser {
 
     final Registration.RegCheck check =
         ImmutableRegCheck.builder()
-            .http(getHealthCheckUrl())
+            .http(getHealthCheckUrl(applicationScheme))
             .interval(String.format("%ds", configuration.getCheckInterval().toSeconds()))
             .deregisterCriticalServiceAfter(
                 String.format("%dm", configuration.getDeregisterInterval().toMinutes()))
@@ -211,10 +212,10 @@ public class ConsulAdvertiser {
     }
   }
 
-  protected String getHealthCheckUrl() {
+    protected String getHealthCheckUrl(String applicationScheme) {
     final UriBuilder builder = UriBuilder.fromPath(environment.getAdminContext().getContextPath());
     builder.path("healthcheck");
-    builder.scheme("http");
+        builder.scheme(applicationScheme);
     if (serviceAddress.get() == null) {
       builder.host("127.0.0.1");
     } else {

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -15,6 +15,18 @@
  */
 package com.smoketurner.dropwizard.consul.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.Consul;
@@ -24,17 +36,12 @@ import com.orbitz.consul.model.agent.ImmutableRegistration;
 import com.smoketurner.dropwizard.consul.ConsulFactory;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.setup.Environment;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ConsulAdvertiserTest {
 


### PR DESCRIPTION
Updated to use the protocol provided to the advertiser for the health check so that if the service is running securely, the health checks will be as well.

* ConsulAdvertiser.java - Updated the getHealthcheckUrl to take the service protocol. 
* ConsulAdvertiserTest.java - Added a test to confirm the appropriate protocol is used on the ImmutableRegCheck.