### PR TITLE
Specify the service address when the host is not static or on a multihomed server

### DIFF
--- a/consul-core/pom.xml
+++ b/consul-core/pom.xml
@@ -38,5 +38,10 @@
             <artifactId>consul-client</artifactId>
             <version>1.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.6</version>
+        </dependency>
     </dependencies>
 </project>

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
@@ -23,12 +23,18 @@ import com.orbitz.consul.model.agent.ImmutableRegistration;
 import com.orbitz.consul.model.agent.Registration;
 import com.smoketurner.dropwizard.consul.ConsulFactory;
 import io.dropwizard.setup.Environment;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import javax.ws.rs.core.UriBuilder;
+import org.apache.commons.net.util.SubnetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.nonNull;
 
 public class ConsulAdvertiser {
 
@@ -36,6 +42,8 @@ public class ConsulAdvertiser {
   private final AtomicReference<Integer> servicePort = new AtomicReference<>();
   private final AtomicReference<Integer> serviceAdminPort = new AtomicReference<>();
   private final AtomicReference<String> serviceAddress = new AtomicReference<>();
+  private final AtomicReference<String> serviceSubnet = new AtomicReference<>();
+  private final AtomicReference<Supplier<String>> serviceAddressSupplier = new AtomicReference<>();
   private final AtomicReference<String> aclToken = new AtomicReference<>();
   private final AtomicReference<Iterable<String>> tags = new AtomicReference<>();
   private final AtomicReference<Map<String, String>> serviceMeta = new AtomicReference<>();
@@ -88,6 +96,22 @@ public class ConsulAdvertiser {
             });
 
     configuration
+        .getServiceSubnet()
+        .ifPresent(
+            subnet -> {
+              LOGGER.info("Using \"{}\" as serviceSubnet from configuration file", subnet);
+              serviceSubnet.set(subnet);
+            });
+
+    configuration
+        .getServiceAddressSupplier()
+        .ifPresent(
+            supplier -> {
+              LOGGER.info("Using \"{}\" as serviceSupplier from configuration file", supplier);
+              serviceAddressSupplier.set(supplier);
+            });
+
+    configuration
         .getTags()
         .ifPresent(
             newTags -> {
@@ -122,17 +146,22 @@ public class ConsulAdvertiser {
     return serviceId;
   }
 
+  public boolean register(final String applicationScheme, final int applicationPort, final int adminPort) {
+      return register(applicationScheme, applicationPort, adminPort, null);
+  }
+
   /**
    * Register the service with Consul
    *
    * @param applicationScheme Scheme the server is listening on
    * @param applicationPort Port the service is listening on
    * @param adminPort Port the admin server is listening on
+   * @param ipAddresses IP addresses of the available that the application is listening on
    * @return true if successfully registered, otherwise false
    * @throws ConsulException When registration fails
    */
   public boolean register(
-      final String applicationScheme, final int applicationPort, final int adminPort) {
+      final String applicationScheme, final int applicationPort, final int adminPort, Collection<String> ipAddresses) {
     final AgentClient agent = consul.agentClient();
     if (agent.isRegistered(serviceId)) {
       LOGGER.info(
@@ -155,7 +184,7 @@ public class ConsulAdvertiser {
 
     final Registration.RegCheck check =
         ImmutableRegCheck.builder()
-            .http(getHealthCheckUrl(applicationScheme))
+            .http(getHealthCheckUrl(applicationScheme, ipAddresses))
             .interval(String.format("%ds", configuration.getCheckInterval().toSeconds()))
             .deregisterCriticalServiceAfter(
                 String.format("%dm", configuration.getDeregisterInterval().toMinutes()))
@@ -170,9 +199,7 @@ public class ConsulAdvertiser {
     }
 
     // If we have set the serviceAddress, add it to the registration.
-    if (serviceAddress.get() != null) {
-      builder.address(serviceAddress.get());
-    }
+    getServiceAddress(ipAddresses).ifPresent(builder::address);
 
     // If we have tags, add them to the registration.
     if (tags.get() != null) {
@@ -188,6 +215,53 @@ public class ConsulAdvertiser {
 
     consul.agentClient().register(builder.build());
     return true;
+}
+
+  /**
+   * Returns the service address from best provided options.
+   * The order of precedence is as follows: serviceAddress, if provided, then
+   * the subnet resolution. If neither is provided or matched, Optional.empty()
+   * is returned.
+   *
+   * @param ipAddresses List of ipAddresses the application is listening on.
+   * @return Optional of the host to register as the service address or empty otherwise
+   */
+  private Optional<String> getServiceAddress(Collection<String> ipAddresses) {
+      if (nonNull(serviceAddress.get())) {
+          return Optional.of(serviceAddress.get());
+      }
+
+      if (nonNull(ipAddresses) && !ipAddresses.isEmpty() && nonNull(serviceSubnet.get())) {
+          Optional<String> ip = findFirstEligibleIpBySubnet(ipAddresses);
+          if (ip.isPresent()){
+              return ip;
+          }
+      }
+
+      if (nonNull(serviceAddressSupplier.get())){
+          try{
+              return Optional.ofNullable(serviceAddressSupplier.get().get());
+          } catch (Exception ex){
+              LOGGER.debug("Service address supplier threw an exception.", ex);
+          }
+      }
+      return Optional.empty();
+  }
+
+ /**
+   * Returns the service address from the list of hosts. It iterates through
+   * the list and finds the first host tht matched the subnet. If none is found,
+   * an empty Optional is returned.
+   *
+   * @param ipAddresses List of ipAddresses the application is listening on.
+   * @return Optional of the host to register as the service address or empty otherwise
+   */
+  private Optional<String> findFirstEligibleIpBySubnet(Collection<String> ipAddresses) {
+      SubnetUtils subnetUtils = new SubnetUtils(serviceSubnet.get());
+      SubnetUtils.SubnetInfo subNetInfo = subnetUtils.getInfo();
+      return ipAddresses.stream()
+          .filter(subNetInfo::isInRange)
+          .findFirst();
   }
 
   /** Deregister a service from Consul */
@@ -199,7 +273,7 @@ public class ConsulAdvertiser {
         return;
       }
     } catch (ConsulException e) {
-      LOGGER.error("Failed to determine if service ID \"{}\" is registered", e);
+      LOGGER.error("Failed to determine if service ID \"{}\" is registered", serviceId, e);
       return;
     }
 
@@ -218,16 +292,12 @@ public class ConsulAdvertiser {
    * @param applicationScheme Scheme the server is listening on
    * @return health check URL
    */
-  protected String getHealthCheckUrl(String applicationScheme) {
+  protected String getHealthCheckUrl(String applicationScheme, Collection<String> hosts) {
     final UriBuilder builder = UriBuilder.fromPath(environment.getAdminContext().getContextPath());
-    builder.path("healthcheck");
-    builder.scheme(applicationScheme);
-    if (serviceAddress.get() == null) {
-      builder.host("127.0.0.1");
-    } else {
-      builder.host(serviceAddress.get());
-    }
-    builder.port(serviceAdminPort.get());
+    builder.path("healthcheck")
+      .scheme(applicationScheme)
+      .host(getServiceAddress(hosts).orElse("127.0.0.1"))
+      .port(serviceAdminPort.get());
     return builder.build().toString();
   }
 }

--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiser.java
@@ -220,7 +220,8 @@ public class ConsulAdvertiser {
   /**
    * Returns the service address from best provided options.
    * The order of precedence is as follows: serviceAddress, if provided, then
-   * the subnet resolution. If neither is provided or matched, Optional.empty()
+   * the subnet resolution, lastly the supplier. If none of the above is
+   * provided or matched, Optional.empty()
    * is returned.
    *
    * @param ipAddresses List of ipAddresses the application is listening on.

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulFactoryTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/ConsulFactoryTest.java
@@ -16,6 +16,7 @@
 package com.smoketurner.dropwizard.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.util.Duration;
@@ -29,6 +30,22 @@ public class ConsulFactoryTest {
     final ConsulFactory expected = createFullyPopulatedConsulFactory();
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void testCorrectlyFormattedSubnet(){
+      final ConsulFactory factory = createFullyPopulatedConsulFactory();
+      factory.setServiceSubnet("192.168.3.0/24");
+      assertThat(factory.getServiceSubnet())
+          .isPresent()
+          .contains("192.168.3.0/24");
+  }
+
+    @Test
+  public void testIncorrectlyFormattedSubnet(){
+      final ConsulFactory factory = createFullyPopulatedConsulFactory();
+      assertThatIllegalArgumentException()
+          .isThrownBy(()->factory.setServiceSubnet("192.168.3.0/"));
+   }
 
   @Test
   public void testNotEqual() {
@@ -59,6 +76,7 @@ public class ConsulFactoryTest {
     consulFactory.setEnabled(true);
     consulFactory.setServicePort(1000);
     consulFactory.setAdminPort(2000);
+    consulFactory.setServiceSubnet("192.168.1.0/24");
     consulFactory.setServiceAddress("localhost");
     consulFactory.setTags(ImmutableList.of("tag1", "tag2"));
     consulFactory.setRetryInterval(Duration.seconds(5));

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulServiceListenerTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulServiceListenerTest.java
@@ -15,8 +15,9 @@
  */
 package com.smoketurner.dropwizard.consul.core;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -24,9 +25,11 @@ import static org.mockito.Mockito.when;
 
 import com.orbitz.consul.ConsulException;
 import io.dropwizard.util.Duration;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import io.dropwizard.util.Sets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,12 +57,14 @@ public class ConsulServiceListenerTest {
         new ConsulServiceListener(
             advertiser, Optional.of(Duration.milliseconds(1)), Optional.of(scheduler));
 
-    when(advertiser.register(anyString(), anyInt(), anyInt()))
+    when(advertiser.register(any(), anyInt(), anyInt(), anyCollection()))
         .thenThrow(new ConsulException("Cannot connect to Consul"))
         .thenReturn(true);
 
-    listener.register(null, 0, 0);
+    Collection<String> hosts = Sets.of("192.168.1.22");
+    listener.register("http", 0, 0, hosts);
 
-    verify(advertiser, timeout(100).atLeast(1)).register(null, 0, 0);
+    verify(advertiser, timeout(100).atLeast(1))
+        .register("http", 0, 0, hosts);
   }
 }


### PR DESCRIPTION
Issue: Service address on multi-homed client #109
Added subnet and supplier fields in the ConsulFactory.java to provide a way to specify the service address when it may not be available for use in a static configuration. The subnet field will allow the ConsulAdvertiser to select the first adapter in the specified subnet. The Supplier allows the user to provide code to be executed at runtime to provide a host based on whatever criteria they choose.