### PR TITLE
Fix NullPointerException thrown by ConsulAdvertiser

### DIFF
--- a/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
+++ b/consul-core/src/main/java/com/smoketurner/dropwizard/consul/ConsulFactory.java
@@ -64,7 +64,8 @@ public class ConsulFactory {
   @NotNull
   @MinDuration(value = 1, unit = TimeUnit.MINUTES)
   private Duration deregisterInterval = Duration.minutes(1);
-  private Optional<String> healthCheckPath;
+
+  private Optional<String> healthCheckPath = Optional.empty();
 
   @JsonProperty
   public boolean isEnabled() {

--- a/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/com/smoketurner/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -102,6 +102,38 @@ public class ConsulAdvertiserTest {
     verify(agent).register(registration);
   }
 
+  /**
+   * Added to verify that NullPointerException is not thrown when a healthCheckPath
+   * is not specified on ConsulFactory.
+   */
+  @Test
+  public void testRegisterWhenHealthCheckPathNotSpecifiedOnFactory() {
+    factory = new ConsulFactory();
+    factory.setServiceName("test");
+    factory.setServiceSubnet("192.168.2.0/24");
+    factory.setServiceAddressSupplier(supplierMock);
+    advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
+
+    when(agent.isRegistered(serviceId)).thenReturn(false);
+    advertiser.register("http", 8080, 8081);
+
+    final ImmutableRegistration registration =
+        ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(ImmutableMap.of("scheme", "http"))
+            .id(serviceId)
+            .build();
+
+    verify(agent).register(registration);
+  }
+
   @Test
   public void testRegisterWithSubnet() {
     when(agent.isRegistered(serviceId)).thenReturn(false);


### PR DESCRIPTION
Initialize the healthCheckPath field to an empty Optional in
ConsulFactory. Otherwise, the ConsulAdvertise constructor
throws NullPointerException (at line 145) because the call to
configuration.getHealthCheckPath() returns a null instead of
an empty Optional.

Add test for this specific situation. Because all the existing
tests set the healthCheckPath, this test has to create a new
ConsulFactory and specifically NOT set the healthCheckPath.